### PR TITLE
remove anzu status when evil-flash-hook is called

### DIFF
--- a/evil-anzu.el
+++ b/evil-anzu.el
@@ -100,6 +100,9 @@
 (define-globalized-minor-mode global-evil-anzu-mode evil-anzu-mode evil-anzu--turn-on
   :group 'evil-anzu)
 
+(defadvice evil-flash-hook (after reset-anzu-information activate)
+  (anzu--reset-status))
+
 (defadvice evil-search (before reset-anzu-information activate)
   (anzu--reset-status))
 


### PR DESCRIPTION
CC:  @z0rch

This PR fixes [4th case](https://github.com/syohex/emacs-anzu/issues/39#issuecomment-69365366).
Please add following configuration in your configuration file if you try this version.

``` lisp
(define-key evil-motion-state-map "n" 'evil-anzu-search-next)
(define-key evil-motion-state-map "N" 'evil-anzu-search-previous)
```

![evil-anzu-fix1](https://cloud.githubusercontent.com/assets/554281/5719758/d2944474-9b5e-11e4-92d4-bcf727c1da11.gif)
