### PR TITLE
only enable evil-anzu if anzu-mode is enabled

### DIFF
--- a/evil-anzu.el
+++ b/evil-anzu.el
@@ -60,6 +60,14 @@ If PATTERN is not specified the current global pattern `evil-ex-search-pattern' 
 (advice-add 'evil-flash-hook   :after #'evil-anzu-prevent-flicker)
 (advice-add 'evil-ex-delete-hl :after #'evil-anzu-reset)
 
+(defun evil-anzu-unload-function ()
+  "unload evil anzu"
+  (advice-remove 'evil-search       #'evil-anzu-start-search)
+  (advice-remove 'evil-ex-find-next #'evil-anzu-search-next)
+  (advice-remove 'evil-flash-hook   #'evil-anzu-prevent-flicker)
+  (advice-remove 'evil-ex-delete-hl #'evil-anzu-reset)
+  nil)
+
 (provide 'evil-anzu)
 
 ;;; evil-anzu.el ends here

--- a/evil-anzu.el
+++ b/evil-anzu.el
@@ -28,29 +28,37 @@
 (require 'evil)
 (require 'anzu)
 
-(defadvice evil-search (after evil-anzu-compat (string forward &optional regexp-p start) activate)
-  (anzu--cons-mode-line-search)
-  (let ((isearch-regexp regexp-p))
-    (anzu--update string)))
+(defun evil-anzu-start-search (string forward &optional regexp-p start)
+  (when anzu-mode (anzu--cons-mode-line-search)
+        (let ((isearch-regexp regexp-p))
+          (anzu--update string))))
 
-(defadvice evil-ex-find-next (after evil-anzu-compat (&optional pattern direction nowrap) activate)
+(defun evil-anzu-search-next (&optional pattern direction nowrap)
   "Make anzu work with the 'evil-search search module.
 If PATTERN is not specified the current global pattern `evil-ex-search-pattern' is used."
-  (anzu--cons-mode-line-search)
-  (let* ((isearch-regexp t)      ; all evil-ex searches are regexp searches
-         (current-pattern (or pattern evil-ex-search-pattern))
-         (regexp (evil-ex-pattern-regex current-pattern)))
-    (save-match-data            ; don't let anzu's searching mess up evil
-      (anzu--update regexp))))
+  (when anzu-mode
+    (anzu--cons-mode-line-search)
+    (let* ((isearch-regexp t) ; all evil-ex searches are regexp searches
+           (current-pattern (or pattern evil-ex-search-pattern))
+           (regexp (evil-ex-pattern-regex current-pattern)))
+      (save-match-data       ; don't let anzu's searching mess up evil
+        (anzu--update regexp)))))
 
-(defadvice evil-flash-hook (after evil-anzu-compat activate)
+(defun evil-anzu-prevent-flicker (&optional force)
   ;; Prevent flickering, only run if timer is not active
-  (unless (memq evil-flash-timer timer-list)
+  (when anzu-mode
+    (unless (memq evil-flash-timer timer-list)
+      (anzu--reset-mode-line))))
+
+(defun evil-anzu-reset (name)
+  (when (and anzu-mode
+             (eq name 'evil-ex-search))
     (anzu--reset-mode-line)))
 
-(defadvice evil-ex-delete-hl (after evil-anzu-compat (name) activate)
-  (when (eq name 'evil-ex-search)
-    (anzu--reset-mode-line)))
+(advice-add 'evil-search       :after #'evil-anzu-start-search)
+(advice-add 'evil-ex-find-next :after #'evil-anzu-search-next)
+(advice-add 'evil-flash-hook   :after #'evil-anzu-prevent-flicker)
+(advice-add 'evil-ex-delete-hl :after #'evil-anzu-reset)
 
 (provide 'evil-anzu)
 


### PR DESCRIPTION
Fixes #8 and ports to the modern advice system. Also add an unload function for removing `evil-anzu` if desired. 