### PR TITLE
Fixes #12: prevent displaying (0/0) when nothing in search-ring

### DIFF
--- a/evil-anzu.el
+++ b/evil-anzu.el
@@ -29,7 +29,10 @@
 (require 'anzu)
 
 (defun evil-anzu-start-search (string forward &optional regexp-p start)
-  (when anzu-mode
+  (when (and anzu-mode
+             (if evil-regexp-search
+                 (car-safe regexp-search-ring)
+               (car-safe search-ring)))
     (anzu--cons-mode-line-search)
     (let ((isearch-regexp regexp-p))
       (anzu--update string))))

--- a/evil-anzu.el
+++ b/evil-anzu.el
@@ -29,10 +29,7 @@
 (require 'anzu)
 
 (defun evil-anzu-start-search (string forward &optional regexp-p start)
-  (when (and anzu-mode
-             (if evil-regexp-search
-                 (car-safe regexp-search-ring)
-               (car-safe search-ring)))
+  (when (and anzu-mode string)
     (anzu--cons-mode-line-search)
     (let ((isearch-regexp regexp-p))
       (anzu--update string))))


### PR DESCRIPTION
This is simple fix for issue #12, simply not executing anzu when nothing in search-ring.
I think doing nothing could be enough solution for this case since `evil-search-next` does nothing in the case as well. 
Thanks.