### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/evil-anzu.el
+++ b/evil-anzu.el
@@ -35,8 +35,9 @@
       (anzu--update string))))
 
 (defun evil-anzu-search-next (&optional pattern direction nowrap)
-  "Make anzu work with the 'evil-search search module.
-If PATTERN is not specified the current global pattern `evil-ex-search-pattern' is used."
+  "Make anzu work with the \\='evil-search search module.
+If PATTERN is not specified the current global pattern
+`evil-ex-search-pattern' is used."
   (when anzu-mode
     (anzu--cons-mode-line-search)
     (let* ((isearch-regexp t) ; all evil-ex searches are regexp searches


### PR DESCRIPTION
To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.

```
 ■  Warning (comp): evil-anzu.el:39:2: Warning: docstring wider than 80
characters
 ■  Warning (comp): evil-anzu.el:39:2: Warning: docstring has wrong
usage of unescaped single quotes (use \= or different quoting)
```