### PR TITLE
Enable lexical binding

### DIFF
--- a/evil-anzu.el
+++ b/evil-anzu.el
@@ -1,4 +1,4 @@
-;;; evil-anzu.el --- anzu for evil-mode
+;;; evil-anzu.el --- anzu for evil-mode -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017 by Syohei YOSHIDA
 


### PR DESCRIPTION
Hi. In Emacs30, not having lexical binding is now a byte compiler warning. I have been using this package for some time with lexical binding enabled and have not encountered any issues nor do I see anything in the code that could cause problems with that.

If any problems do arise, feel free to ping me and I will follow up this PR.